### PR TITLE
Render getting started snippets with syntax highlighter

### DIFF
--- a/examples/qk-next/app/globals.css
+++ b/examples/qk-next/app/globals.css
@@ -124,6 +124,12 @@
   }
 }
 
+@layer components {
+  .quick-start-snippet {
+    @apply !m-0 !bg-transparent whitespace-pre-wrap break-words px-3 py-3 pr-14 text-xs leading-[1.4] font-mono sm:text-sm;
+  }
+}
+
 /* Prevent mobile zoom on inputs by ensuring font-size >= 16px */
 input,
 textarea,

--- a/examples/qk-next/app/page.tsx
+++ b/examples/qk-next/app/page.tsx
@@ -1024,19 +1024,21 @@ export default function Home(): JSX.Element {
       </div>
 
       {/* Toggle button to open results drawer */}
-      <button
-        type="button"
-        onClick={() => setIsResultsOpen(v => !v)}
-        aria-expanded={isResultsOpen}
-        aria-controls="results-drawer"
-        title={isResultsOpen ? 'Hide results' : 'Show results'}
-        className="fixed bottom-10 left-1/2 -translate-x-1/2 z-[70] inline-flex items-center justify-center rounded-full border bg-background shadow px-3 py-2 text-xs hover:bg-accent transition-colors"
-      >
-        <ChevronUp
-          className={`h-4 w-4 transition-transform ${isResultsOpen ? 'rotate-180' : ''}`}
-        />
-        <span className="ml-2">{isResultsOpen ? 'Hide' : 'Results'}</span>
-      </button>
+      {!isDrawerOpen && (
+        <button
+          type="button"
+          onClick={() => setIsResultsOpen(v => !v)}
+          aria-expanded={isResultsOpen}
+          aria-controls="results-drawer"
+          title={isResultsOpen ? 'Hide results' : 'Show results'}
+          className="fixed bottom-10 left-1/2 -translate-x-1/2 z-[70] inline-flex items-center justify-center rounded-full border bg-background shadow px-3 py-2 text-xs hover:bg-accent transition-colors"
+        >
+          <ChevronUp
+            className={`h-4 w-4 transition-transform ${isResultsOpen ? 'rotate-180' : ''}`}
+          />
+          <span className="ml-2">{isResultsOpen ? 'Hide' : 'Results'}</span>
+        </button>
+      )}
 
       {/* Bottom drawer with results table */}
       {isResultsOpen && (

--- a/examples/qk-next/app/page.tsx
+++ b/examples/qk-next/app/page.tsx
@@ -761,7 +761,11 @@ export default function Home(): JSX.Element {
                           {section.description}
                         </p>
                       </div>
-                      <div className="relative overflow-hidden rounded-md border bg-muted">
+                      <div
+                        role="region"
+                        aria-label={`${section.title} code example`}
+                        className="relative overflow-hidden rounded-md border bg-muted"
+                      >
                         <button
                           type="button"
                           onClick={() =>

--- a/examples/qk-next/app/page.tsx
+++ b/examples/qk-next/app/page.tsx
@@ -32,7 +32,7 @@ import { toast } from 'sonner';
 import Aurora from '@/components/reactbits/blocks/Backgrounds/Aurora/Aurora';
 import { PGlite } from '@electric-sql/pglite';
 import { useViewportInfo } from './hooks/use-viewport-info';
-import { trackQueryKitIssue, trackQueryKitUsage } from '@/lib/utils';
+import { cn, trackQueryKitIssue, trackQueryKitUsage } from '@/lib/utils';
 import {
   Drawer,
   DrawerTrigger,
@@ -198,12 +198,12 @@ export default function Home(): JSX.Element {
   // Register languages once
   useEffect(() => {
     try {
-      const highlighter =
-        SyntaxHighlighter as unknown as typeof SyntaxHighlighter;
+      const highlighter = SyntaxHighlighter as typeof SyntaxHighlighter & {
+        registerLanguage: (name: string, language: unknown) => void;
+      };
       highlighter.registerLanguage('sql', sqlLanguage);
       highlighter.registerLanguage('typescript', typescriptLanguage);
       highlighter.registerLanguage('bash', bashLanguage);
-      // JSON language registration removed
     } catch (error) {
       console.error('Failed to register languages:', error);
     }
@@ -769,11 +769,12 @@ export default function Home(): JSX.Element {
                           }
                           aria-label={`Copy ${section.title}`}
                           title={`Copy ${section.title}`}
-                          className={`absolute right-2 inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent bg-transparent text-muted-foreground transition-colors hover:bg-muted/60 sm:right-3 ${
+                          className={cn(
+                            'absolute right-2 inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent bg-transparent text-muted-foreground transition-colors hover:bg-muted/60 sm:right-3',
                             section.code.includes('\n')
                               ? 'top-2 sm:top-3'
                               : 'top-1/2 -translate-y-1/2 sm:top-1/2 sm:-translate-y-1/2'
-                          }`}
+                          )}
                         >
                           <Copy
                             className={`h-4 w-4 transition-all duration-200 ${
@@ -794,19 +795,8 @@ export default function Home(): JSX.Element {
                           <SyntaxHighlighter
                             language={section.language}
                             style={atomOneDarkReasonable}
-                            customStyle={{
-                              background: 'transparent',
-                              margin: 0,
-                              padding: '12px',
-                              paddingRight: '3.25rem',
-                              fontSize: '0.75rem',
-                              lineHeight: '1.4',
-                              whiteSpace: 'pre-wrap',
-                              wordBreak: 'break-word',
-                              overflowWrap: 'anywhere'
-                            }}
                             wrapLongLines
-                            className="text-xs font-mono sm:text-sm"
+                            className="quick-start-snippet"
                           >
                             {section.code}
                           </SyntaxHighlighter>


### PR DESCRIPTION
## Summary
- register the HLJS bash language alongside SQL and TypeScript so the getting-started drawer can highlight every snippet with `react-syntax-highlighter`
- wrap each quick-start code block in a scrollable container with pre-wrap styling so the code renders visibly beneath the transparent copy button

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d87d9d01ec8320817d25ef162ae1c6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a right-side "Getting started" drawer with copyable, syntax-highlighted snippets and small UX tweaks (query param open, conditional results button).
> 
> - **UI/Docs**:
>   - **Getting-started Drawer**: Introduces a right-side drawer with quick-start sections (`install`, `schema`, `usage`) rendered via `SyntaxHighlighter` and a copy-to-clipboard button per block.
>   - Registers `bash` and `typescript` languages (in addition to `sql`) for syntax highlighting.
>   - Adds new icons and `Drawer` components; sections defined via `quickStartSections`.
> - **UX**:
>   - Supports `?drawer=open` to auto-open the drawer.
>   - Hides the floating Results toggle while the drawer is open.
>   - Copy feedback state for snippets and improved code block styling (scrollable, pre-wrap, preserved long lines).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b90553d943d6ab0c3420b6281aa8656af9d92bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->