### PR TITLE
QueryKit deny values field

### DIFF
--- a/src/security/types.ts
+++ b/src/security/types.ts
@@ -83,6 +83,31 @@ export interface ISecurityOptions {
   denyValues?: Record<string, Array<string | number | boolean | null>>;
 
   /**
+   * Whether to allow dot notation in field names (e.g., "user.name", "metadata.tags").
+   * When disabled, queries with dots in field names will be rejected.
+   *
+   * Use cases for DISABLING dot notation:
+   * - Public-facing search APIs where users should only query flat, top-level fields
+   * - Preventing access to table-qualified columns in SQL joins (e.g., "users.password")
+   * - Simpler security model when your schema doesn't have nested/JSON data
+   * - Preventing users from probing internal table structures
+   *
+   * @default true
+   *
+   * @example
+   * ```typescript
+   * // Disable dot notation for a public search API
+   * allowDotNotation: false
+   *
+   * // This would block queries like:
+   * // user.email == "test@example.com"  // Rejected
+   * // metadata.tags == "sale"           // Rejected
+   * // email == "test@example.com"       // Allowed
+   * ```
+   */
+  allowDotNotation?: boolean;
+
+  /**
    * Maximum nesting depth of query expressions.
    * Prevents deeply nested queries that could impact performance.
    *
@@ -218,6 +243,7 @@ export const DEFAULT_SECURITY_OPTIONS: Required<ISecurityOptions> = {
   allowedFields: [], // Empty means "use schema fields"
   denyFields: [], // Empty means no denied fields
   denyValues: {}, // Empty means no denied values for any field
+  allowDotNotation: true, // Allow dot notation by default for backward compatibility
 
   // Query complexity limits
   maxQueryDepth: 10, // Maximum nesting level of expressions


### PR DESCRIPTION
Add `denyValues` security option to prevent specific values from being queried for given fields.

This feature extends security to the value property of schema fields, allowing granular control over what data can be accessed or filtered by users.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffedef08-ec04-4b33-aeaf-55be382551ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ffedef08-ec04-4b33-aeaf-55be382551ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces value-level query restrictions for finer-grained security control.
> 
> - Adds `denyValues` to `ISecurityOptions` and initializes it in `DEFAULT_SECURITY_OPTIONS`
> - Integrates `validateDenyValues` into `QuerySecurityValidator.validate`, rejecting matches in single values and `IN` arrays (including nested logical expressions)
> - Implements `isValueDenied` with support for string/number coercion and explicit `null` handling
> - Expands tests to cover strings, numbers, booleans, nulls, arrays, dot-notation fields, interactions with `allowedFields`/`denyFields`, and nested expressions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fab0cb992158dab7d6e7b7570050cbd43cf1bc35. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->