### PR TITLE
NPM trusted publishers pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,18 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write  # Required for NPM Trusted Publishers (OIDC)
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-          always-auth: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -53,9 +53,7 @@ jobs:
           TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: node -e 'const v=require("./package.json").version; const tag=(process.env.TAG||"").replace(/^v/,""); if(v!==tag){console.error("package.json version "+v+" does not match tag "+tag); process.exit(1)} else {console.log("Version matches tag:", v)}'
 
-      - name: Publish package to npmjs
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --no-git-checks --access public
+      - name: Publish package to npmjs with provenance
+        run: pnpm publish --no-git-checks --access public --provenance
 
 


### PR DESCRIPTION
Upgrade `publish.yml` to use NPM's Trusted Publishers for more secure, token-less publishing with provenance.

---
<a href="https://cursor.com/background-agent?bcId=bc-beac815f-beb0-4926-9bba-7ed4f166b5a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-beac815f-beb0-4926-9bba-7ed4f166b5a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves npm publishing to NPM Trusted Publishers (OIDC) with provenance and improves tag handling.
> 
> - Grants `id-token: write` permission and publishes with `--provenance`
> - Drops token-based auth (`NODE_AUTH_TOKEN`, `always-auth`) in favor of OIDC
> - `actions/checkout` now checks out `${{ github.event.release.tag_name || inputs.tag }}` to support manual dispatch
> - Retains tag presence/version verification before publish
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4cb5f118180d2a63191c74d751042730a4cbc6a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->