### PR TITLE
Querykit issue 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ dueDate:{2023-01-01 TO 2023-01-31}      # Exclusive range
 name:/Todo.*/         # Regular expression
 title:intro*          # Wildcard matching
 
-# Boolean operators
+# Boolean operators (case insensitive)
 status:active AND priority:>2     # AND operator
 status:active OR status:pending   # OR operator
 NOT expired:true      # NOT operator
 -expired:true         # Alternative NOT syntax
+status:active and name:test       # Lowercase operators work too
+status:active Or priority:>2      # Mixed case also supported
 
 # Grouping
 (status:active OR status:pending) AND priority:<3
@@ -89,6 +91,81 @@ NOT expired:true      # NOT operator
 # Implicit AND (space between expressions)
 status:active priority:>2
 ```
+
+## Parser Options
+
+`createQueryKit` accepts a `parserOptions` field to configure the underlying `QueryParser`. This avoids the need for manual query string preprocessing.
+
+### Field Mappings
+
+Map user-friendly field names to actual schema column names:
+
+```typescript
+const qk = createQueryKit({
+  adapter: drizzleAdapter,
+  schema: { users },
+  parserOptions: {
+    fieldMappings: {
+      author: 'author_name',
+      name: 'title',
+      created_by: 'created_by_name',
+    }
+  }
+});
+
+// Users can query with friendly names:
+const results = await qk
+  .query('users')
+  .where('author:"Jane Doe" AND name:safety')
+  .execute();
+// Internally resolves to: author_name:"Jane Doe" AND title:safety
+```
+
+### Case-Insensitive Fields
+
+Enable case-insensitive field name matching:
+
+```typescript
+const qk = createQueryKit({
+  adapter: drizzleAdapter,
+  schema: { users },
+  parserOptions: {
+    caseInsensitiveFields: true,
+    fieldMappings: { status: 'task_status' }
+  }
+});
+
+// All of these resolve to task_status:active
+qk.query('users').where('Status:active');
+qk.query('users').where('STATUS:active');
+qk.query('users').where('status:active');
+```
+
+## Tolerant Parse Mode
+
+By default, `createQueryKit` throws on any malformed input. For search UIs where queries may be submitted in a transiently incomplete state, enable tolerant mode to leverage `parseWithContext`'s built-in error recovery:
+
+```typescript
+const qk = createQueryKit({
+  adapter: drizzleAdapter,
+  schema: { tasks },
+  tolerant: true
+});
+
+// These auto-recover instead of throwing:
+await qk.query('tasks').where('status:active AND').execute();
+// → Autofixes to: 'status:active'
+
+await qk.query('tasks').where('status:"incomplete').execute();
+// → Autofixes to: 'status:"incomplete"'
+```
+
+Recovery types supported by tolerant mode:
+- **Trailing operators** — `status:active AND` → `status:active`
+- **Unclosed quotes** — `status:"active` → `status:"active"`
+- **Unbalanced parentheses** — `(status:active` → `(status:active)`
+
+If autofix also fails, an error is still thrown, ensuring silent data corruption never occurs.
 
 ## Installation
 
@@ -1045,7 +1122,7 @@ await qk.query('tasks')
 - [x] Implement Lucene-style query syntax parser using Liqe
 - [x] Create type-safe query building API
 - [x] Develop internal AST representation
-- [x] Implement consistent syntax for logical operators (AND, OR, NOT)
+- [x] Implement consistent syntax for logical operators (AND, OR, NOT) with case-insensitive support
 - [x] Support standard comparison operators (==, !=, >, >=, <, <=)
 - [x] Real-time input parsing for search UIs
 - [x] Autocomplete suggestions with schema awareness

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,10 @@ importers:
         version: 20.17.32
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.1.0
-        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^7.1.0
-        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -47,10 +47,10 @@ importers:
         version: 3.5.3
       ts-jest:
         specifier: ^29.1.2
-        version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.32))(typescript@5.8.3)
+        version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.32))(typescript@5.9.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.8.3
+        specifier: ^5.9.3
+        version: 5.9.3
 
 packages:
 
@@ -1760,8 +1760,8 @@ packages:
     resolution: {integrity: sha512-9YvLNnORDpI+vghLU/Nf+zSv0kL47KbVJ1o3sKgoTefl6i+zebxbiDQWoe/oWWqPhIgQdRZRT1KA9sCPL810SA==}
     engines: {node: '>=16'}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2324,34 +2324,34 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.8.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.8.3)
+      ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.0
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2360,21 +2360,21 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       debug: 4.4.0
       eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@5.8.3)
+      ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@7.18.0': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -2383,18 +2383,18 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@5.8.3)
+      ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.6.1(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -3711,13 +3711,13 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@1.4.3(typescript@5.8.3):
+  ts-api-utils@1.4.3(typescript@5.9.3):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   ts-error@1.0.6: {}
 
-  ts-jest@29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.32))(typescript@5.8.3):
+  ts-jest@29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.32))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -3729,7 +3729,7 @@ snapshots:
       make-error: 1.3.6
       semver: 7.7.1
       type-fest: 4.40.1
-      typescript: 5.8.3
+      typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.27.1
@@ -3749,7 +3749,7 @@ snapshots:
 
   type-fest@4.40.1: {}
 
-  typescript@5.8.3: {}
+  typescript@5.9.3: {}
 
   undici-types@6.19.8: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,34 @@ export interface IQueryKitOptions<
   adapterOptions?: IAdapterOptions & { [key: string]: unknown };
 
   /**
+   * Parser configuration options passed through to the QueryParser.
+   * Allows configuring field name mappings, case sensitivity, and other
+   * parser-level settings at the QueryKit instance level.
+   *
+   * @example
+   * parserOptions: {
+   *   caseInsensitiveFields: true,
+   *   fieldMappings: {
+   *     author: 'author_name',
+   *     name: 'title',
+   *   }
+   * }
+   */
+  parserOptions?: IParserOptions;
+
+  /**
+   * When true, the execution pipeline uses `parseWithContext` with autofix
+   * instead of `parse`, recovering gracefully from incomplete or malformed
+   * queries (trailing operators, unclosed quotes, etc.) instead of throwing.
+   *
+   * Useful for search UIs where queries may be in a transiently incomplete
+   * state when submitted.
+   *
+   * @default false
+   */
+  tolerant?: boolean;
+
+  /**
    * Virtual field definitions for context-aware query expansion.
    * Virtual fields allow shortcuts like `my:assigned` that expand to
    * real schema fields at query execution time.
@@ -197,8 +225,9 @@ export function createQueryKit<
     [K in keyof TSchema & string]: unknown;
   }
 >(options: IQueryKitOptions<TSchema, TContext>): QueryKit<TSchema, TRows> {
-  const parser = new QueryParser();
+  const parser = new QueryParser(options.parserOptions);
   const securityValidator = new QuerySecurityValidator(options.security);
+  const isTolerant = options.tolerant ?? false;
 
   // Initialize adapter if options provided. If adapter is already initialized,
   // calling initialize again with the same options should be a no-op for most adapters.
@@ -224,8 +253,31 @@ export function createQueryKit<
     ): IWhereClause<TRows[K]> => {
       return {
         where: (queryString: string): IQueryExecutor<TRows[K]> => {
-          // Parse the query
-          const expressionAst = parser.parse(queryString);
+          // Parse the query, optionally using tolerant mode with autofix
+          let expressionAst: QueryExpression;
+          if (isTolerant) {
+            const contextResult = parser.parseWithContext(queryString);
+            if (contextResult.success && contextResult.ast) {
+              expressionAst = contextResult.ast;
+            } else if (contextResult.recovery?.autofix) {
+              const retryResult = parser.parseWithContext(
+                contextResult.recovery.autofix
+              );
+              if (retryResult.success && retryResult.ast) {
+                expressionAst = retryResult.ast;
+              } else {
+                throw new Error(
+                  `Failed to parse query even after autofix: ${contextResult.error?.message ?? 'Unknown error'}`
+                );
+              }
+            } else {
+              throw new Error(
+                `Failed to parse query: ${contextResult.error?.message ?? 'Unknown error'}`
+              );
+            }
+          } else {
+            expressionAst = parser.parse(queryString);
+          }
 
           // Execution state accumulated via fluent calls
           let orderByState: Record<string, 'asc' | 'desc'> = {};

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -559,4 +559,191 @@ describe('QueryKit Integration Tests', () => {
       expect(whereStr).toContain('deleted');
     });
   });
+
+  describe('createQueryKit with parserOptions (fixes #19)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should apply fieldMappings during query execution', async () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } },
+        parserOptions: {
+          fieldMappings: { name: 'title' }
+        }
+      });
+
+      await qk.query('todos').where('name:test').execute();
+
+      expect(mockWhere).toHaveBeenCalled();
+      const whereArg = mockWhere.mock.calls[0][0] as unknown as SQL;
+      const whereStr = getSqlString(whereArg);
+      expect(whereStr).toContain('title');
+    });
+
+    it('should apply caseInsensitiveFields during query execution', async () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } },
+        parserOptions: {
+          caseInsensitiveFields: true,
+          fieldMappings: { status: 'status' }
+        }
+      });
+
+      await qk.query('todos').where('Status:active').execute();
+
+      expect(mockWhere).toHaveBeenCalled();
+      const whereArg = mockWhere.mock.calls[0][0] as unknown as SQL;
+      const whereStr = getSqlString(whereArg);
+      expect(whereStr).toContain('status');
+    });
+
+    it('should combine caseInsensitiveFields and fieldMappings', async () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } },
+        parserOptions: {
+          caseInsensitiveFields: true,
+          fieldMappings: { author: 'title' }
+        }
+      });
+
+      await qk.query('todos').where('AUTHOR:test').execute();
+
+      expect(mockWhere).toHaveBeenCalled();
+      const whereArg = mockWhere.mock.calls[0][0] as unknown as SQL;
+      const whereStr = getSqlString(whereArg);
+      expect(whereStr).toContain('title');
+    });
+  });
+
+  describe('createQueryKit tolerant mode (fixes #19)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should auto-recover from trailing operator', async () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } },
+        tolerant: true
+      });
+
+      const results = await qk
+        .query('todos')
+        .where('status:active AND')
+        .execute();
+      expect(results).toBeDefined();
+    });
+
+    it('should auto-recover from unclosed quote', async () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } },
+        tolerant: true
+      });
+
+      const results = await qk.query('todos').where('status:"active').execute();
+      expect(results).toBeDefined();
+    });
+
+    it('should parse valid queries normally in tolerant mode', async () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } },
+        tolerant: true
+      });
+
+      const results = await qk
+        .query('todos')
+        .where('status:active AND priority:>1')
+        .execute();
+      expect(results).toBeDefined();
+      expect(mockWhere).toHaveBeenCalled();
+    });
+
+    it('should throw in strict mode (default)', () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } }
+      });
+
+      expect(() => qk.query('todos').where('status:active AND')).toThrow();
+    });
+
+    it('should throw when tolerant autofix also fails', () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } },
+        tolerant: true
+      });
+
+      expect(() => qk.query('todos').where('')).toThrow();
+    });
+  });
+
+  describe('lowercase boolean operators via createQueryKit (fixes #19)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should execute queries with lowercase "and"', async () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } }
+      });
+
+      const results = await qk
+        .query('todos')
+        .where('priority:>1 and status:active')
+        .execute();
+      expect(results).toBeDefined();
+      expect(results).toHaveLength(2);
+    });
+
+    it('should execute queries with lowercase "or"', async () => {
+      const localAdapter = new DrizzleAdapter();
+      localAdapter.initialize({ db: mockDb, schema: mockSchema });
+
+      const qk = createQueryKit({
+        adapter: localAdapter,
+        schema: { todos: { id: {}, title: {}, priority: {}, status: {} } }
+      });
+
+      const results = await qk
+        .query('todos')
+        .where('status:active or status:pending')
+        .execute();
+      expect(results).toBeDefined();
+    });
+  });
 });

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -868,6 +868,58 @@ describe('QueryParser', () => {
       expect(parser.parse(query)).toEqual(expected);
     });
 
+    // Boolean operator case insensitivity (fixes #19)
+    describe('boolean operator case insensitivity', () => {
+      it('should parse lowercase "and"', () => {
+        const ast = parser.parse('status:active and name:test');
+        expect(ast.type).toBe('logical');
+        expect((ast as ILogicalExpression).operator).toBe('AND');
+      });
+
+      it('should parse lowercase "or"', () => {
+        const ast = parser.parse('a:1 or b:2');
+        expect(ast.type).toBe('logical');
+        expect((ast as ILogicalExpression).operator).toBe('OR');
+      });
+
+      it('should parse lowercase "not"', () => {
+        const ast = parser.parse('not status:archived');
+        expect(ast.type).toBe('logical');
+        expect((ast as ILogicalExpression).operator).toBe('NOT');
+      });
+
+      it('should parse mixed case "And", "Or"', () => {
+        const ast = parser.parse('a:1 And b:2 Or c:3');
+        expect(ast.type).toBe('logical');
+      });
+
+      it('should produce identical ASTs for case variants', () => {
+        const upper = parser.parse('status:active AND name:test');
+        const lower = parser.parse('status:active and name:test');
+        expect(JSON.stringify(upper)).toBe(JSON.stringify(lower));
+      });
+
+      it('should preserve lowercase "and" inside quoted values', () => {
+        const ast = parser.parse('name:"and"');
+        expect(ast.type).toBe('comparison');
+        expect((ast as IComparisonExpression).value).toBe('and');
+      });
+
+      it('should preserve lowercase "or" inside quoted values', () => {
+        const ast = parser.parse('title:"or not"');
+        expect(ast.type).toBe('comparison');
+        expect((ast as IComparisonExpression).value).toBe('or not');
+      });
+
+      it('should handle lowercase operators combined with parentheses', () => {
+        const ast = parser.parse(
+          '(status:active or status:pending) and priority:>2'
+        );
+        expect(ast.type).toBe('logical');
+        expect((ast as ILogicalExpression).operator).toBe('AND');
+      });
+    });
+
     // IN operator syntax tests using consistent key:[values] pattern
     describe('IN operator syntax (key:[values])', () => {
       it('should parse "field:[val1, val2, val3]" bracket array syntax', () => {

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -918,6 +918,56 @@ describe('QueryParser', () => {
         expect(ast.type).toBe('logical');
         expect((ast as ILogicalExpression).operator).toBe('AND');
       });
+
+      it('should NOT uppercase "and" when it is a field value', () => {
+        const ast = parser.parse('name:and');
+        expect(ast.type).toBe('comparison');
+        expect((ast as IComparisonExpression).field).toBe('name');
+        expect((ast as IComparisonExpression).value).toBe('and');
+      });
+
+      it('should NOT uppercase "or" when it is a field value', () => {
+        const ast = parser.parse('type:or');
+        expect(ast.type).toBe('comparison');
+        expect((ast as IComparisonExpression).field).toBe('type');
+        expect((ast as IComparisonExpression).value).toBe('or');
+      });
+
+      it('should NOT uppercase "not" when it is a field value', () => {
+        const ast = parser.parse('gate:not');
+        expect(ast.type).toBe('comparison');
+        expect((ast as IComparisonExpression).field).toBe('gate');
+        expect((ast as IComparisonExpression).value).toBe('not');
+      });
+
+      it('should NOT uppercase boolean keywords after comparison operators', () => {
+        const ast = parser.parse('priority:>=or');
+        expect(ast.type).toBe('comparison');
+        expect((ast as IComparisonExpression).value).toBe('or');
+      });
+
+      it('should NOT uppercase "not" when used as a field name', () => {
+        const ast = parser.parse('not:disabled');
+        expect(ast.type).toBe('comparison');
+        expect((ast as IComparisonExpression).field).toBe('not');
+        expect((ast as IComparisonExpression).value).toBe('disabled');
+      });
+
+      it('should handle mixed value and operator usage', () => {
+        const ast = parser.parse('gate:and and gate:or');
+        expect(ast.type).toBe('logical');
+        expect((ast as ILogicalExpression).operator).toBe('AND');
+        const left = (ast as ILogicalExpression).left as IComparisonExpression;
+        const right = (ast as ILogicalExpression)
+          .right as IComparisonExpression;
+        expect(left.value).toBe('and');
+        expect(right.value).toBe('or');
+      });
+
+      it('should preserve boolean keywords in bracket array syntax', () => {
+        const ast = parser.parse('gate:[and, or, not]');
+        expect(ast.type).toBe('logical');
+      });
     });
 
     // IN operator syntax tests using consistent key:[values] pattern

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -81,6 +81,7 @@ export class QueryParser implements IQueryParser {
    * Pre-process a query string to convert non-standard syntax to Liqe-compatible syntax.
    * Supports:
    * - `field:[val1, val2, val3]` → `(field:val1 OR field:val2 OR field:val3)`
+   * - Lowercase boolean operators: `and` → `AND`, `or` → `OR`, `not` → `NOT`
    *
    * This keeps the syntax consistent with the `key:value` pattern used throughout QueryKit:
    * - `priority:>2` (comparison)
@@ -89,6 +90,11 @@ export class QueryParser implements IQueryParser {
    */
   private preprocessQuery(query: string): string {
     let result = query;
+
+    // Normalize lowercase boolean operators to uppercase.
+    // Liqe only recognizes uppercase AND, OR, NOT as boolean operators;
+    // lowercase variants are treated as bare search terms causing crashes.
+    result = this.normalizeBooleanOperators(result);
 
     // Handle `field:[val1, val2, ...]` syntax (array-like, not range)
     // Pattern: fieldName:[value1, value2, ...]
@@ -105,6 +111,83 @@ export class QueryParser implements IQueryParser {
     });
 
     return result;
+  }
+
+  /**
+   * Normalize lowercase boolean operators (and, or, not) to their uppercase
+   * equivalents (AND, OR, NOT) while preserving content inside quoted strings.
+   *
+   * Liqe only recognizes uppercase boolean operators. Without normalization,
+   * lowercase variants are parsed as bare search terms, which produces an
+   * incompatible AST that crashes during conversion.
+   */
+  private normalizeBooleanOperators(query: string): string {
+    const parts: Array<{ text: string; quoted: boolean }> = [];
+    let current = '';
+    let inDoubleQuotes = false;
+    let inSingleQuotes = false;
+
+    for (let i = 0; i < query.length; i++) {
+      const char = query[i];
+      const nextChar = query[i + 1];
+
+      if ((inDoubleQuotes || inSingleQuotes) && char === '\\' && nextChar) {
+        current += char + nextChar;
+        i++;
+        continue;
+      }
+
+      if (char === '"' && !inSingleQuotes) {
+        if (!inDoubleQuotes) {
+          if (current.length > 0) {
+            parts.push({ text: current, quoted: false });
+            current = '';
+          }
+          inDoubleQuotes = true;
+          current += char;
+        } else {
+          current += char;
+          parts.push({ text: current, quoted: true });
+          current = '';
+          inDoubleQuotes = false;
+        }
+        continue;
+      }
+
+      if (char === "'" && !inDoubleQuotes) {
+        if (!inSingleQuotes) {
+          if (current.length > 0) {
+            parts.push({ text: current, quoted: false });
+            current = '';
+          }
+          inSingleQuotes = true;
+          current += char;
+        } else {
+          current += char;
+          parts.push({ text: current, quoted: true });
+          current = '';
+          inSingleQuotes = false;
+        }
+        continue;
+      }
+
+      current += char;
+    }
+
+    if (current.length > 0) {
+      parts.push({ text: current, quoted: inDoubleQuotes || inSingleQuotes });
+    }
+
+    return parts
+      .map(part => {
+        if (part.quoted) {
+          return part.text;
+        }
+        return part.text.replace(/\b(and|or|not)\b/gi, match =>
+          match.toUpperCase()
+        );
+      })
+      .join('');
   }
 
   /**

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -183,8 +183,9 @@ export class QueryParser implements IQueryParser {
         if (part.quoted) {
           return part.text;
         }
-        return part.text.replace(/\b(and|or|not)\b/gi, match =>
-          match.toUpperCase()
+        return part.text.replace(
+          /(?<![^\s()])\b(and|or|not)\b(?![^\s()])/gi,
+          match => match.toUpperCase()
         );
       })
       .join('');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement case-insensitive boolean operators, expose parser options, and add a tolerant parsing mode to address issue #19.

The primary bug fixed involved lowercase boolean operators (`and`, `or`, `not`) causing crashes because Liqe only recognizes uppercase versions, treating lowercase as bare search terms. This PR normalizes these operators before parsing. Additionally, a new `tolerant` mode leverages Liqe's `parseWithContext` to automatically fix common query syntax errors like unclosed quotes or trailing operators, significantly improving user experience.

<div><a href="https://cursor.com/agents/bc-2dd75be8-d8ea-49c4-8665-86be128ccf51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dd75be8-d8ea-49c4-8665-86be128ccf51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->